### PR TITLE
Fix issues with Gracenote agent checking

### DIFF
--- a/tv_grab_zap2epg
+++ b/tv_grab_zap2epg
@@ -409,16 +409,16 @@ def mainRun(userdata):
                                 if not episode.startswith("MV"):
                                     if epicon == '1':
                                         if edict['epimage'] is not None and edict['epimage'] != '':
-                                            fh.write('\t\t<icon src="https://gracenote.tmsimg.com/assets/' + edict['epimage'] + '.jpg" />\n')
+                                            fh.write('\t\t<icon src="https://demo.tmsimg.com/assets/' + edict['epimage'] + '.jpg" />\n')
                                         else:
                                             if edict['epthumb'] is not None and edict['epthumb'] != '':
-                                                fh.write('\t\t<icon src="https://gracenote.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
+                                                fh.write('\t\t<icon src="https://demo.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
                                     if epicon == '2':
                                         if edict['epthumb'] is not None and edict['epthumb'] != '':
-                                            fh.write('\t\t<icon src="https://gracenote.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
+                                            fh.write('\t\t<icon src="https://demo.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
                                 if episode.startswith("MV"):
                                     if edict['epthumb'] is not None and edict['epthumb'] != '':
-                                        fh.write('\t\t<icon src="https://gracenote.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
+                                        fh.write('\t\t<icon src="https://demo.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
                                 if not any(i in ['New', 'Live'] for i in edict['epflag']):
                                     fh.write("\t\t<previously-shown ")
                                     if edict['epoad'] is not None and int(edict['epoad']) > 0:
@@ -445,7 +445,7 @@ def mainRun(userdata):
                                     for c in edict['epcredits']:
                                         if c['assetId'] is not None:
                                             crole=c['role']
-                                            fh.write('\t\t\t<' + c['role'].lower() + ' role="' + convHTML(c['characterName']) + '" src="https://gracenote.tmsimg.com/assets/' + c['assetId'] + '">' + convHTML(c['name']) + '</' + c['role'].lower() + '>\n')
+                                            fh.write('\t\t\t<' + c['role'].lower() + ' role="' + convHTML(c['characterName']) + '" src="https://demo.tmsimg.com/assets/' + c['assetId'] + '">' + convHTML(c['name']) + '</' + c['role'].lower() + '>\n')
                                         else:
                                             fh.write('\t\t\t<' + c['role'].lower() + ' role="' + convHTML(c['characterName']) + '">' + convHTML(c['name']) + '</' + c['role'].lower() + '>\n')
                                     fh.write("\t\t</credits>\n")
@@ -642,7 +642,7 @@ def mainRun(userdata):
                                     data = 'programSeriesID=' + EPseries
                                     data_encode = data.encode('utf-8')
                                     try:
-                                        URLcontent = urllib.request.Request(url, data=data_encode)
+                                        URLcontent = urllib.request.Request(url, data=data_encode, headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) C>
                                         JSONcontent = urllib.request.urlopen(URLcontent).read()
                                         if JSONcontent:
                                             with open(fileDir,"wb+") as f:
@@ -842,6 +842,7 @@ def mainRun(userdata):
                 try:
                     logging.info('Downloading guide data for: %i', int(gridtime))
                     url = 'http://tvlistings.gracenote.com/api/grid?lineupId=&timespan=3&headendId=' + lineupcode + '&country=' + country + '&device=' + device + '&postalCode=' + zipcode + '&time=' + str(int(gridtime)) + '&pref=-&userId=-'
+                    req = urllib.request.Request(url, data=None, headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36'})
                     saveContent = urllib.request.urlopen(url).read()
                     savepage(fileDir, saveContent)
                 except:

--- a/tv_grab_zap2epg
+++ b/tv_grab_zap2epg
@@ -843,7 +843,7 @@ def mainRun(userdata):
                     logging.info('Downloading guide data for: %i', int(gridtime))
                     url = 'http://tvlistings.gracenote.com/api/grid?lineupId=&timespan=3&headendId=' + lineupcode + '&country=' + country + '&device=' + device + '&postalCode=' + zipcode + '&time=' + str(int(gridtime)) + '&pref=-&userId=-'
                     req = urllib.request.Request(url, data=None, headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36'})
-                    saveContent = urllib.request.urlopen(url).read()
+                    saveContent = urllib.request.urlopen(req).read()
                     savepage(fileDir, saveContent)
                 except:
                     logging.warning('Could not download guide data for: %i', int(gridtime))

--- a/tv_grab_zap2epg
+++ b/tv_grab_zap2epg
@@ -409,16 +409,16 @@ def mainRun(userdata):
                                 if not episode.startswith("MV"):
                                     if epicon == '1':
                                         if edict['epimage'] is not None and edict['epimage'] != '':
-                                            fh.write('\t\t<icon src="https://demo.tmsimg.com/assets/' + edict['epimage'] + '.jpg" />\n')
+                                            fh.write('\t\t<icon src="https://zap2it.tmsimg.com/assets/' + edict['epimage'] + '.jpg" />\n')
                                         else:
                                             if edict['epthumb'] is not None and edict['epthumb'] != '':
-                                                fh.write('\t\t<icon src="https://demo.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
+                                                fh.write('\t\t<icon src="https://zap2it.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
                                     if epicon == '2':
                                         if edict['epthumb'] is not None and edict['epthumb'] != '':
-                                            fh.write('\t\t<icon src="https://demo.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
+                                            fh.write('\t\t<icon src="https://zap2it.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
                                 if episode.startswith("MV"):
                                     if edict['epthumb'] is not None and edict['epthumb'] != '':
-                                        fh.write('\t\t<icon src="https://demo.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
+                                        fh.write('\t\t<icon src="https://zap2it.tmsimg.com/assets/' + edict['epthumb'] + '.jpg" />\n')
                                 if not any(i in ['New', 'Live'] for i in edict['epflag']):
                                     fh.write("\t\t<previously-shown ")
                                     if edict['epoad'] is not None and int(edict['epoad']) > 0:
@@ -445,7 +445,7 @@ def mainRun(userdata):
                                     for c in edict['epcredits']:
                                         if c['assetId'] is not None:
                                             crole=c['role']
-                                            fh.write('\t\t\t<' + c['role'].lower() + ' role="' + convHTML(c['characterName']) + '" src="https://demo.tmsimg.com/assets/' + c['assetId'] + '">' + convHTML(c['name']) + '</' + c['role'].lower() + '>\n')
+                                            fh.write('\t\t\t<' + c['role'].lower() + ' role="' + convHTML(c['characterName']) + '" src="https://zap2it.tmsimg.com/assets/' + c['assetId'] + '">' + convHTML(c['name']) + '</' + c['role'].lower() + '>\n')
                                         else:
                                             fh.write('\t\t\t<' + c['role'].lower() + ' role="' + convHTML(c['characterName']) + '">' + convHTML(c['name']) + '</' + c['role'].lower() + '>\n')
                                     fh.write("\t\t</credits>\n")


### PR DESCRIPTION
1. Make script look like MacOS Mozilla client agent.  Gracenote seems to have turned on agent checking and blocks the default python script agent.

2. Rename gracenote.tmsimg.com to demo.tmsimg.com since the gracenote hostname wasn't working for me.